### PR TITLE
Adds event details bottom sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+where adb

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/models/event_model.dart
+++ b/lib/models/event_model.dart
@@ -1,0 +1,26 @@
+// event_model.dart
+import 'package:flutter/material.dart';
+
+class EventModel {
+  final String id;              // Dodane pole id
+  final String title;           // Tytuł wydarzenia
+  final String description;     // Krótki opis lub szczegóły
+  final String date;            // Data, np. "Piątek, 4 wrz 2025"
+  final String time;            // Godzina, np. "18:00 - 19:00"
+  final String location;        // Lokalizacja (szczegóły sali, adres)
+  final bool freeEntry;         // Czy wydarzenie jest darmowe
+  final Color? backgroundColor; // Tło karty, opcjonalnie
+  final int colorVariant;       // Dodane pole
+
+  EventModel({
+    required this.id,           // Dodane pole id
+    required this.title,
+    required this.description,
+    required this.date,
+    required this.time,
+    required this.location,
+    required this.freeEntry,
+    this.backgroundColor,
+    this.colorVariant = 0,      // Domyślna wartość
+  });
+}

--- a/lib/screens/home/components/events_section.dart
+++ b/lib/screens/home/components/events_section.dart
@@ -2,20 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:my_uz/icons/my_uz_icons.dart';
 import 'package:my_uz/theme/text_style.dart';
 import 'package:my_uz/widgets/cards/event_card.dart';
-
-/// Model wydarzenia (prosty – YAGNI)
-class EventModel {
-  final String id;
-  final String title;
-  final String description;
-  final int colorVariant; // 0 / 1
-  const EventModel({
-    required this.id,
-    required this.title,
-    required this.description,
-    this.colorVariant = 0,
-  });
-}
+import 'package:my_uz/models/event_model.dart';
+import 'package:my_uz/screens/home/details/event_details.dart';
 
 /// Sekcja: Wydarzenia
 /// Card height (Figma): 84
@@ -66,11 +54,16 @@ class EventsSection extends StatelessWidget {
                       borderRadius: BorderRadius.circular(8),
                       splashColor: Colors.transparent,
                       highlightColor: Colors.transparent,
-                      onTap: () => onTap(e),
+                      onTap: () {
+                        EventDetailsSheet.open(context, e);
+                        // Możesz też wywołać onTap(e) jeśli potrzebujesz
+                        // onTap(e);
+                      },
                       child: EventCard(
                         title: e.title,
                         description: e.description,
                         backgroundColor: bg,
+                        eventModel: e,
                       ),
                     ),
                   ),

--- a/lib/screens/home/details/event_details.dart
+++ b/lib/screens/home/details/event_details.dart
@@ -1,0 +1,298 @@
+// event_details.dart
+import 'package:flutter/material.dart';
+import 'package:my_uz/icons/my_uz_icons.dart';
+import 'package:my_uz/models/event_model.dart';
+import 'package:my_uz/theme/app_colors.dart';
+import 'package:my_uz/theme/text_style.dart';
+
+abstract class EventDetailsSheet {
+  static Future<void> open(BuildContext context, EventModel event) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      barrierColor: Colors.black54,
+      builder: (_) => _EventDetailsDraggable(eventModel: event),
+    );
+  }
+}
+
+const double _kMinChildFraction = 0.40;
+const double _kMaxChildFraction = 1.0;
+const double _kTopRadius = 24;
+const double _kHitArea = 48;
+const double _kCircleSmall = 32;
+const double _kCircleLarge = 40;
+const double _kIconToTextGap = 12;
+
+class _EventDetailsDraggable extends StatelessWidget {
+  final EventModel eventModel;
+  const _EventDetailsDraggable({required this.eventModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      minChildSize: _kMinChildFraction,
+      initialChildSize: 1.0,
+      maxChildSize: _kMaxChildFraction,
+      builder: (context, scrollController) {
+        return _EventSheetScaffold(
+          scrollController: scrollController,
+          child: _EventDetailsContent(eventModel: eventModel),
+        );
+      },
+    );
+  }
+}
+
+class _EventSheetScaffold extends StatelessWidget {
+  final Widget child;
+  final ScrollController scrollController;
+  const _EventSheetScaffold({required this.child, required this.scrollController});
+
+  @override
+  Widget build(BuildContext context) {
+    final topPadding = MediaQuery.of(context).padding.top;
+    const horizontal = 16.0;
+    const handleTopGap = 8.0;
+    const handleToXGap = 8.0;
+    const xToHeaderGap = 12.0;
+    return Container(
+      margin: EdgeInsets.zero,
+      padding: EdgeInsets.only(top: topPadding + handleTopGap),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(_kTopRadius)),
+        boxShadow: [
+          BoxShadow(color: Color(0x4C000000), blurRadius: 3, offset: Offset(0, 1)),
+          BoxShadow(color: Color(0x26000000), blurRadius: 8, offset: Offset(0, 4), spreadRadius: 3),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(horizontal, 0, horizontal, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _Grip(),
+            const SizedBox(height: handleToXGap),
+            Row(
+              children: [
+                _AdaptiveIconSlot(
+                  iconSize: 24,
+                  semanticsLabel: 'Zamknij szczegóły wydarzenia',
+                  isButton: true,
+                  onTap: () => Navigator.of(context).maybePop(),
+                  child: Icon(MyUz.x_close, size: 24, color: const Color(0xFF1D192B)),
+                ),
+                const Spacer(),
+              ],
+            ),
+            const SizedBox(height: xToHeaderGap),
+            Expanded(
+              child: SingleChildScrollView(
+                controller: scrollController,
+                child: child,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EventDetailsContent extends StatelessWidget {
+  final EventModel eventModel;
+  const _EventDetailsContent({required this.eventModel});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    const headerBottomGap = 28.0;
+    const rowVerticalGap = 12.0;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _AdaptiveIconSlot(
+              iconSize: 16,
+              child: _TypeColorMarker(
+                color: eventModel.backgroundColor ?? const Color(0xFFDAF5D7), // taki sam jak w EventCard
+              ),
+            ),
+            const SizedBox(width: _kIconToTextGap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    eventModel.title,
+                    style: AppTextStyle.myUZTitleLarge.copyWith(
+                      fontWeight: FontWeight.w500,
+                      color: const Color(0xFF1D192B),
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    _dateLine(eventModel.date, eventModel.time),
+                    style: AppTextStyle.myUZBodyMedium.copyWith(
+                      color: cs.onSurfaceVariant,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: headerBottomGap),
+        _DetailRow(icon: MyUz.marker_pin_04, label: eventModel.location.isNotEmpty ? eventModel.location : 'Lokalizacja -'),
+        const SizedBox(height: rowVerticalGap),
+        _DetailRow(icon: MyUz.menu_03, label: eventModel.description.isNotEmpty ? eventModel.description : 'Opis -'),
+        const SizedBox(height: rowVerticalGap),
+        _DetailRow(
+          icon: MyUz.trophy_01, // ZAMIANA z MyUz.ticket na istniejącą ikonę
+          label: eventModel.freeEntry ? 'Wstęp wolny' : 'Wstęp płatny',
+        ),
+      ],
+    );
+  }
+
+  static String _dateLine(String date, String time) {
+    return '$date • $time';
+  }
+}
+
+class _Grip extends StatelessWidget {
+  const _Grip();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 4,
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+}
+
+class _AdaptiveIconSlot extends StatelessWidget {
+  final double iconSize;
+  final Widget child;
+  final Color? background;
+  final VoidCallback? onTap;
+  final String? semanticsLabel;
+  final bool isButton;
+  const _AdaptiveIconSlot({
+    required this.iconSize,
+    required this.child,
+    this.background,
+    this.onTap,
+    this.semanticsLabel,
+    this.isButton = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final double circle = iconSize >= 24 ? _kCircleLarge : _kCircleSmall;
+    Widget inner = SizedBox(
+      width: _kHitArea,
+      height: _kHitArea,
+      child: Center(
+        child: Container(
+          width: circle,
+          height: circle,
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(circle / 2),
+          ),
+          alignment: Alignment.center,
+          child: SizedBox(
+            width: iconSize,
+            height: iconSize,
+            child: FittedBox(fit: BoxFit.contain, child: child),
+          ),
+        ),
+      ),
+    );
+
+    if (onTap != null) {
+      inner = Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(circle / 2),
+          splashColor: Colors.black12,
+          onTap: onTap,
+          child: inner,
+        ),
+      );
+    }
+    if (semanticsLabel != null) {
+      inner = Semantics(
+        button: isButton,
+        label: semanticsLabel,
+        child: inner,
+      );
+    }
+    return inner;
+  }
+}
+
+class _TypeColorMarker extends StatelessWidget {
+  final Color color;
+  const _TypeColorMarker({required this.color});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 16,
+      height: 16,
+      decoration: ShapeDecoration(
+        color: color,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _DetailRow({required this.icon, required this.label});
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _AdaptiveIconSlot(
+          iconSize: 20,
+          child: Icon(icon, size: 20, color: cs.onSurface),
+        ),
+        const SizedBox(width: _kIconToTextGap),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 14),
+            child: Text(
+              label,
+              style: AppTextStyle.myUZBodyLarge.copyWith(color: cs.onSurface),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NoGlow extends ScrollBehavior {
+  const _NoGlow();
+  @override
+  Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) => child;
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:my_uz/theme/text_style.dart';
 // MODELE
 import 'package:my_uz/models/class_model.dart';
 import 'package:my_uz/models/task_model.dart';
+import 'package:my_uz/models/event_model.dart';
 // DODANE: ekran szczegółów zajęć
 import 'package:my_uz/screens/home/details/class_details.dart';
 import 'package:my_uz/screens/home/details/task_details.dart';
@@ -94,10 +95,34 @@ class _HomeScreenState extends State<HomeScreen> {
         deadline: now2.add(const Duration(days: 6)),
       ),
     ];
-    _events = const [
-      EventModel(id: 'e1', title: 'Juwenalia 2025', description: 'Koncerty i atrakcje na kampusie.'),
-      EventModel(id: 'e2', title: 'Dzień sportu', description: 'Turniej siatkówki + biegi.'),
-      EventModel(id: 'e3', title: 'Hackathon UZ', description: '24h kodowania – zgłoś zespół.'),
+    _events = [
+      EventModel(
+        id: 'e1',
+        title: 'Juwenalia 2025',
+        description: 'Koncerty i atrakcje na kampusie.',
+        date: 'Piątek, 4 paź 2025',
+        time: '18:00 - 23:00',
+        location: 'Kampus UZ',
+        freeEntry: true,
+      ),
+      EventModel(
+        id: 'e2',
+        title: 'Dzień sportu',
+        description: 'Turniej siatkówki + biegi.',
+        date: 'Sobota, 10 paź 2025',
+        time: '10:00 - 16:00',
+        location: 'Stadion UZ',
+        freeEntry: false,
+      ),
+      EventModel(
+        id: 'e3',
+        title: 'Hackathon UZ',
+        description: '24h kodowania – zgłoś zespół.',
+        date: 'Wtorek, 21 paź 2025',
+        time: '09:00 - 09:00',
+        location: 'Aula UZ',
+        freeEntry: true,
+      ),
     ];
   }
 

--- a/lib/widgets/cards/event_card.dart
+++ b/lib/widgets/cards/event_card.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:my_uz/theme/text_style.dart';
+import 'package:my_uz/screens/home/details/event_details.dart';
+import 'package:my_uz/models/event_model.dart';
 
 /// EventCard – karta “Wydarzenia”
-/// Figma height: 84 px (analogiczna struktura do TaskCard)
-/// 12 + 20 + 8 + 32 + 12 = 84
 class EventCard extends StatelessWidget {
   static const double _kHeightEvent = 84;
 
@@ -11,11 +11,13 @@ class EventCard extends StatelessWidget {
   final String description;
   final Color? backgroundColor;
   final bool hugHeight;
+  final EventModel eventModel;
 
   const EventCard({
     super.key,
     required this.title,
     required this.description,
+    required this.eventModel,
     this.backgroundColor,
     this.hugHeight = false,
   });
@@ -55,11 +57,18 @@ class EventCard extends StatelessWidget {
       ),
     );
 
-    if (adaptive) return inner;
-
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: _kHeightEvent),
-      child: inner,
+    if (adaptive) {
+      return GestureDetector(
+        onTap: () => EventDetailsSheet.open(context, eventModel),
+        child: inner,
+      );
+    }
+    return GestureDetector(
+      onTap: () => EventDetailsSheet.open(context, eventModel),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: _kHeightEvent),
+        child: inner,
+      ),
     );
   }
 }


### PR DESCRIPTION
Introduces a bottom sheet to display detailed information about events.

This includes creating a new `EventModel` to hold event data,
a new screen `event_details.dart` that implements the bottom sheet
and updating the `EventsSection` to open the sheet on tap.

The `EventCard` is also updated to trigger the bottom sheet opening.
The previous `EventModel` definition in `events_section.dart` has been removed.
Sample event data has been added to the home screen.
